### PR TITLE
Update CLI executor to verify error using exitValue

### DIFF
--- a/src/main/groovy/net/researchgate/release/cli/Executor.groovy
+++ b/src/main/groovy/net/researchgate/release/cli/Executor.groovy
@@ -36,7 +36,7 @@ class Executor {
         process.waitForProcessOutput(out, err)
         logger?.info("Running $commands produced output: [${out.toString().trim()}]")
 
-        if (err.toString()) {
+        if (process.exitValue()) {
             def message = "Running $commands produced an error: [${err.toString().trim()}]"
 
             if (options['failOnStderr'] as boolean) {


### PR DESCRIPTION
CLI Executor should use process' exit value instead of stderr. Some git hosts write to stderr regardless of process execution success.